### PR TITLE
Refactor speak_with_voicevox as callable

### DIFF
--- a/speak_with_voicevox.py
+++ b/speak_with_voicevox.py
@@ -1,35 +1,57 @@
+"""Utility for synthesising speech using a local VOICEVOX server."""
+
+from __future__ import annotations
+
 import requests
 import soundfile as sf
 import simpleaudio as sa
 
-# 音声化したいテキストを取得（ファイルからでもOK）
-with open("chat_output.txt", "r", encoding="utf-8") as f:
-    text = f.read()
 
-# VOICEVOX設定
-speaker_id = 1  # 例：四国めたん（ノーマル）
-host = "http://127.0.0.1:50021"
+def speak_with_voicevox(
+    text: str,
+    *,
+    speaker_id: int = 1,
+    host: str = "http://127.0.0.1:50021",
+) -> None:
+    """Synthesis ``text`` with VOICEVOX and play the resulting audio.
 
-# 1. 音声合成用クエリ作成
-query = requests.post(
-    f"{host}/audio_query",
-    params={"text": text, "speaker": speaker_id}
-)
-query.raise_for_status()
-audio_query = query.json()
+    Parameters
+    ----------
+    text:
+        The text to be converted into speech.
+    speaker_id:
+        Identifier of the VOICEVOX speaker. ``1`` corresponds to 四国めたん.
+    host:
+        VOICEVOX engine host URL.
+    """
 
-# 2. 音声データ生成
-synthesis = requests.post(
-    f"{host}/synthesis",
-    params={"speaker": speaker_id},
-    json=audio_query
-)
-synthesis.raise_for_status()
+    # 1. 音声合成用クエリ作成
+    query_response = requests.post(
+        f"{host}/audio_query", params={"text": text, "speaker": speaker_id}
+    )
+    query_response.raise_for_status()
+    audio_query = query_response.json()
 
-# 3. 音声データを再生
-audio_data = synthesis.content
-with open("output.wav", "wb") as f:
-    f.write(audio_data)
+    # 2. 音声データ生成
+    synthesis_response = requests.post(
+        f"{host}/synthesis",
+        params={"speaker": speaker_id},
+        json=audio_query,
+    )
+    synthesis_response.raise_for_status()
 
-data, samplerate = sf.read("output.wav")
-sa.play_buffer((data * 32767).astype("int16"), 1, 2, samplerate).wait_done()
+    # 3. 音声データを再生
+    audio_data = synthesis_response.content
+    output_file = "output.wav"
+    with open(output_file, "wb") as f:
+        f.write(audio_data)
+
+    data, samplerate = sf.read(output_file)
+    sa.play_buffer((data * 32767).astype("int16"), 1, 2, samplerate).wait_done()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual testing entry point
+    with open("chat_output.txt", "r", encoding="utf-8") as f:
+        text = f.read().strip()
+
+    speak_with_voicevox(text)


### PR DESCRIPTION
## Summary
- expose `speak_with_voicevox(text: str)` for VOICEVOX synthesis
- avoid running synthesis on import and keep manual entry point under `__main__`

## Testing
- `python -m py_compile chat_with_gpt.py main.py speak_with_voicevox.py voicevox_test.py`

------
https://chatgpt.com/codex/tasks/task_e_6850bac59648832c9317a189751525ad