### PR TITLE
Add conversation context and system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,7 @@ Run the main script:
 ```bash
 python main.py
 ```
-Then type your prompt. The reply from ChatGPT will be spoken aloud.
+You'll be prompted for an optional system prompt when the script starts.
+After that, type your prompt. The last 10 messages are kept as context and
+the reply from ChatGPT will be spoken aloud. Each response is limited to
+200 tokens.

--- a/chat_with_gpt.py
+++ b/chat_with_gpt.py
@@ -1,6 +1,9 @@
 import os
-from openai import OpenAI
+from typing import Dict, List
+
 from dotenv import load_dotenv
+from openai import OpenAI
+
 
 # .env ファイルから環境変数を読み込む
 load_dotenv()
@@ -8,12 +11,54 @@ load_dotenv()
 # APIキーを環境変数から取得してクライアントを初期化
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
-def get_response(prompt):
+# --- Conversation management -------------------------------------------------
+
+_system_prompt: str = ""
+_conversation_history: List[Dict[str, str]] = []
+
+
+def set_system_prompt(prompt: str) -> None:
+    """Set the system prompt and clear conversation history."""
+
+    global _system_prompt, _conversation_history
+    _system_prompt = prompt
+    _conversation_history.clear()
+
+
+def _build_messages(user_prompt: str) -> List[Dict[str, str]]:
+    """Return the messages list to send to the OpenAI API."""
+
+    messages: List[Dict[str, str]] = []
+    if _system_prompt:
+        messages.append({"role": "system", "content": _system_prompt})
+
+    # Keep only the last 10 messages (combined user and assistant)
+    messages.extend(_conversation_history[-10:])
+    messages.append({"role": "user", "content": user_prompt})
+    return messages
+
+
+def _update_history(user_prompt: str, assistant_reply: str) -> None:
+    """Append the latest conversation turn and trim to 10 messages."""
+
+    _conversation_history.append({"role": "user", "content": user_prompt})
+    _conversation_history.append({"role": "assistant", "content": assistant_reply})
+    if len(_conversation_history) > 10:
+        del _conversation_history[:-10]
+
+
+def get_response(prompt: str) -> str:
+    """Send ``prompt`` to the ChatGPT API and return the reply."""
+
+    messages = _build_messages(prompt)
     response = client.chat.completions.create(
         model="gpt-4o",  # 他に gpt-4-turbo や gpt-3.5-turbo も可
-        messages=[{"role": "user", "content": prompt}]
+        messages=messages,
+        max_tokens=200,
     )
-    return response.choices[0].message.content.strip()
+    reply = response.choices[0].message.content.strip()
+    _update_history(prompt, reply)
+    return reply
 
 if __name__ == "__main__":
     prompt = input("ユーザーの発言: ")

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from chat_with_gpt import get_response
+from chat_with_gpt import get_response, set_system_prompt
 from speak_with_voicevox import speak_with_voicevox
 
 def chat_and_speak(prompt: str):
@@ -9,6 +9,10 @@ def chat_and_speak(prompt: str):
     speak_with_voicevox(response)
 
 if __name__ == "__main__":
+    system_prompt = input("システムプロンプトを入力してください (空でスキップ): ")
+    if system_prompt:
+        set_system_prompt(system_prompt)
+
     while True:
         user_input = input("あなた: ")
         if user_input.lower() in {"exit", "quit"}:


### PR DESCRIPTION
## Summary
- allow setting a system prompt when the app starts
- keep the last 10 conversation messages as history
- limit responses to 200 tokens
- document new behaviour in README

## Testing
- `python -m py_compile chat_with_gpt.py main.py speak_with_voicevox.py`


------
https://chatgpt.com/codex/tasks/task_e_6850c395220c832cb1dbe43596156a2f