### PR TITLE
Add system prompt file loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Run the main script:
 ```bash
 python main.py
 ```
-You'll be prompted for an optional system prompt when the script starts.
+If a `system_prompt.txt` file exists in the repository root, its contents will
+be used as the system prompt automatically. You'll still be prompted for an
+optional system prompt when the script starts, which can override the file
+contents.
 After that, type your prompt. The last 10 messages are kept as context and
 the reply from ChatGPT will be spoken aloud. Each response is limited to
 200 tokens.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,13 @@
+import os
 from chat_with_gpt import get_response, set_system_prompt
 from speak_with_voicevox import speak_with_voicevox
+
+# system_prompt.txt が存在する場合は内容をシステムプロンプトとして設定
+if os.path.exists("system_prompt.txt"):
+    with open("system_prompt.txt", "r", encoding="utf-8") as f:
+        file_prompt = f.read().strip()
+        if file_prompt:
+            set_system_prompt(file_prompt)
 
 def chat_and_speak(prompt: str):
     response = get_response(prompt)


### PR DESCRIPTION
## Summary
- load system prompt from `system_prompt.txt` on startup
- document how to use `system_prompt.txt`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError for `requests`)*
- `pip install -r requirements.txt` *(fails: could not install packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6852281136a8832cb084822f6aa963a6