### PR TITLE
Add speaker and speed options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Run the main script:
 ```bash
 python main.py
 ```
+You can optionally pass a VOICEVOX speaker ID and speaking speed:
+```bash
+python main.py --speaker 8 --speed 1.2
+```
 If a `system_prompt.txt` file exists in the repository root, its contents will
 be used as the system prompt automatically. You'll still be prompted for an
 optional system prompt when the script starts, which can override the file

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import os
 import time
+import argparse
 from chat_with_gpt import get_response, set_system_prompt, reset_history
 from speak_with_voicevox import speak_with_voicevox
 
@@ -27,7 +28,19 @@ def show_typing_effect(text: str) -> None:
             time.sleep(0.05)
 
 
-def chat_and_speak(prompt: str):
+def chat_and_speak(prompt: str, *, speaker: int = 1, speed: float | None = None) -> None:
+    """Send ``prompt`` to ChatGPT and speak the reply.
+
+    Parameters
+    ----------
+    prompt:
+        The user prompt to send to ChatGPT.
+    speaker:
+        VOICEVOX speaker ID passed to :func:`speak_with_voicevox`.
+    speed:
+        Optional speed scale forwarded to :func:`speak_with_voicevox`.
+    """
+
     response = get_response(prompt)
     print("ChatGPT:", response)
 
@@ -36,9 +49,26 @@ def chat_and_speak(prompt: str):
     show_typing_effect(response)
 
     # After the whole text is written start speaking
-    speak_with_voicevox(response)
+    speak_with_voicevox(response, speaker_id=speaker, speed=speed)
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Chat with GPT and read responses aloud using VOICEVOX",
+    )
+    parser.add_argument(
+        "--speaker",
+        type=int,
+        default=1,
+        help="VOICEVOX speaker ID",
+    )
+    parser.add_argument(
+        "--speed",
+        type=float,
+        default=None,
+        help="Speed scale for speech (1.0 is normal)",
+    )
+    args = parser.parse_args()
+
     system_prompt = input("システムプロンプトを入力してください (空でスキップ): ")
     if system_prompt:
         set_system_prompt(system_prompt)
@@ -52,4 +82,4 @@ if __name__ == "__main__":
             reset_history()
             print("[履歴をリセットしました]")
             continue
-        chat_and_speak(user_input)
+        chat_and_speak(user_input, speaker=args.speaker, speed=args.speed)


### PR DESCRIPTION
## Summary
- allow setting `--speaker` and `--speed` in `main.py`
- forward these options when speaking
- document command-line usage example

## Testing
- `python -m py_compile chat_with_gpt.py main.py speak_with_voicevox.py voicevox_test.py`

------
https://chatgpt.com/codex/tasks/task_e_6858d2fa63c0832ca9c2bdd0d260df46