### PR TITLE
Add speaker_id usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ from speak_with_voicevox import speak_with_voicevox
 speak_with_voicevox("こんにちは", speed=1.2)
 ```
 
+
+### Selecting a voice
+
+Each VOICEVOX voice is identified by a `speaker_id`. Pass this value to
+`speak_with_voicevox` to choose which speaker to use:
+
+```python
+speak_with_voicevox("text", speaker_id=8)
+```


### PR DESCRIPTION
## Summary
- document how to choose a VOICEVOX speaker

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6858d2ff282c832c85d1560c11a557f2