### PR TITLE
Remove obsolete typed buffer in typing effect

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,10 +14,8 @@ if os.path.exists("system_prompt.txt"):
 def show_typing_effect(text: str) -> None:
     """Write ``text`` to ``chat_output.txt`` one character at a time."""
 
-    typed = ""
     with open("chat_output.txt", "w", encoding="utf-8") as f:
         for ch in text:
-            typed += ch
             f.write(ch)
             f.flush()
             try:


### PR DESCRIPTION
## Summary
- drop unused `typed` variable in `show_typing_effect`

## Testing
- `python -m py_compile main.py speak_with_voicevox.py chat_with_gpt.py`


------
https://chatgpt.com/codex/tasks/task_e_6858d301b0ac832c9e378e1e64f9e75f