### PR TITLE
Add chat log helper

### DIFF
--- a/chat_log.py
+++ b/chat_log.py
@@ -1,0 +1,22 @@
+"""Chat logging helper functions."""
+
+from __future__ import annotations
+
+
+def append_chat_to_log(role: str, message: str, path: str = "chat_log.txt") -> None:
+    """Append a chat ``message`` with ``role`` to ``path``.
+
+    Parameters
+    ----------
+    role:
+        Role name, e.g. ``"user"`` or ``"bot"``.
+    message:
+        Chat message to log.
+    path:
+        Log file path relative to the current working directory. Defaults to
+        ``"chat_log.txt"`` in the repository root.
+    """
+
+    line = f"{role}::{message}\n"
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(line)

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import time
 import argparse
 from chat_with_gpt import get_response, set_system_prompt, reset_history
 from speak_with_voicevox import speak_with_voicevox
+from chat_log import append_chat_to_log
 
 # system_prompt.txt が存在する場合は内容をシステムプロンプトとして設定
 if os.path.exists("system_prompt.txt"):
@@ -39,7 +40,9 @@ def chat_and_speak(prompt: str, *, speaker: int = 1, speed: float | None = None)
         Optional speed scale forwarded to :func:`speak_with_voicevox`.
     """
 
+    append_chat_to_log("user", prompt)
     response = get_response(prompt)
+    append_chat_to_log("bot", response)
     print("ChatGPT:", response)
 
     # Show typing effect and update chat_output.txt


### PR DESCRIPTION
## Summary
- add `append_chat_to_log` helper
- log user prompts and bot replies in `main.py`

## Testing
- `python -m py_compile chat_log.py main.py chat_with_gpt.py speak_with_voicevox.py voicevox_test.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6858ea2ceef0832ca31abeb777f7309c