### PR TITLE
Add browser-based chat log viewer

### DIFF
--- a/chat_ui.html
+++ b/chat_ui.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>Chat UI</title>
+<style>
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+}
+#chat-area {
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+  height: 100vh;
+  box-sizing: border-box;
+  overflow-y: auto;
+  background-color: #f5f5f5;
+}
+.bubble {
+  padding: 8px 12px;
+  border-radius: 12px;
+  margin: 4px 0;
+  max-width: 70%;
+  word-wrap: break-word;
+}
+.bubble.user {
+  align-self: flex-end;
+  background-color: #cfe9ba;
+  text-align: right;
+}
+.bubble.bot {
+  align-self: flex-start;
+  background-color: #fff;
+  border: 1px solid #ccc;
+}
+</style>
+</head>
+<body>
+<div id="chat-area"></div>
+<script>
+function renderChat(text) {
+  const chatArea = document.getElementById('chat-area');
+  chatArea.innerHTML = '';
+  text.trim().split('\n').forEach(line => {
+    line = line.trim();
+    if (!line) return;
+    const div = document.createElement('div');
+    div.classList.add('bubble');
+    if (/^(ユーザー:|User:)/i.test(line)) {
+      div.classList.add('user');
+      div.textContent = line.replace(/^(ユーザー:|User:)/i, '').trim();
+    } else if (/^(AI:|Bot:)/i.test(line)) {
+      div.classList.add('bot');
+      div.textContent = line.replace(/^(AI:|Bot:)/i, '').trim();
+    } else {
+      // default to bot style
+      div.classList.add('bot');
+      div.textContent = line;
+    }
+    chatArea.appendChild(div);
+  });
+  chatArea.scrollTop = chatArea.scrollHeight;
+}
+
+function fetchLog() {
+  fetch('chat_log.txt')
+    .then(res => res.text())
+    .then(text => {
+      if (text !== window.lastLog) {
+        window.lastLog = text;
+        renderChat(text);
+      }
+    })
+    .catch(err => console.error(err));
+}
+
+setInterval(fetchLog, 1000);
+fetchLog();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `chat_ui.html` to display LINE-style chat bubbles
- periodically fetch `chat_log.txt` and update the DOM

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858ea2f2b0c832caed685bb36a5952a