### PR TITLE
Implement typing effect before speech

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ def chat_and_speak(prompt: str, *, speaker: int = 1, speed: float | None = None)
     print("ChatGPT:", response)
 
     # Show typing effect and update chat_output.txt
+    show_typing_effect(response)
 
     # After the whole text is written start speaking
     speak_with_voicevox(response, speaker_id=speaker, speed=speed)


### PR DESCRIPTION
## Summary
- write ChatGPT replies with a typing effect
- call `show_typing_effect` before passing text to VOICEVOX

## Testing
- `python -m py_compile main.py chat_with_gpt.py speak_with_voicevox.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6858ea308b6c832c94f60f7f1cc6672f